### PR TITLE
[Feat] Control the queued computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.4.0
+
+* Able to set the max number of the queued computations and control how a new computation is added to the Queue.
+* Able to compute a priority computation (promote a computation to the top of the Queue).
+
 ## 5.3.0
 
 * Able to add options and flags directly into to Dart to Js Compiler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 5.4.0
 
-* Able to set the max number of the queued computations and control how a new computation is added to the Queue.
-* Able to compute a priority computation (promote a computation to the top of the Queue).
+* Set the max number of the queued computations.
+* Control how a new computation is added to the Queue.
+* Compute a priority computation (promote a computation to the top of the Queue).
 
 ## 5.3.0
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,10 @@ You can set the `maxCount` (the max number of the queued computations) of an `Is
 When creating a new `IsolateManager` or `IsolateManagerShared`, you can specify the `queueStrategy` to control the way that a new computation is added or a computation is got from the Queue. There are 3 base strategies:
 
 ```dart
-/// Remove the newest computation if the [maxCount] is exceeded (default).
+/// Unlimited queued computations (default).
+QueueStrategyUnlimited()
+
+/// Remove the newest computation if the [maxCount] is exceeded.
 QueueStrategyRemoveNewest();
 
 /// Remove the oldest computation if the [maxCount] is exceeded.
@@ -283,6 +286,14 @@ QueueStrategyDiscardIncoming()
 You can extend the `QueueStrategy` to create your own strategy. For instances:
 
 ```dart
+class QueueStrategyUnlimited<R, P> extends QueueStrategy<R, P> {
+  /// Unlimited queued computations.
+  QueueStrategyUnlimited();
+
+  @override
+  bool continueIfMaxCountExceeded() => true;
+}
+
 class QueueStrategyRemoveNewest<R, P> extends QueueStrategy<R, P> {
   /// Remove the newest computation if the [maxCount] is exceeded.
   QueueStrategyRemoveNewest({super.maxCount = 0});

--- a/README.md
+++ b/README.md
@@ -269,23 +269,23 @@ When creating a new `IsolateManager` or `IsolateManagerShared`, you can specify 
 
 ```dart
 /// Remove the newest computation if the [maxCount] is exceeded (default).
-IsolateQueueStrategyRemoveNewest();
+QueueStrategyRemoveNewest();
 
 /// Remove the oldest computation if the [maxCount] is exceeded.
-IsolateQueueStrategyRemoveOldest()
+QueueStrategyRemoveOldest()
 
 /// Discard the new incoming computation if the [maxCount] is exceeded.
-IsolateQueueStrategyDiscardIncoming()
+QueueStrategyDiscardIncoming()
 ```
 
 ### Create a custom strategy
 
-You can extend the `IsolateQueueStrategy` to create your own strategy. For instances:
+You can extend the `QueueStrategy` to create your own strategy. For instances:
 
 ```dart
-class IsolateQueueStrategyRemoveNewest<R, P> extends IsolateQueueStrategy<R, P> {
+class QueueStrategyRemoveNewest<R, P> extends QueueStrategy<R, P> {
   /// Remove the newest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveNewest({super.maxCount = 0});
+  QueueStrategyRemoveNewest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
@@ -296,9 +296,9 @@ class IsolateQueueStrategyRemoveNewest<R, P> extends IsolateQueueStrategy<R, P> 
   }
 }
 
-class IsolateQueueStrategyRemoveOldest<R, P> extends IsolateQueueStrategy<R, P> {
+class QueueStrategyRemoveOldest<R, P> extends QueueStrategy<R, P> {
   /// Remove the oldest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveOldest({super.maxCount = 0});
+  QueueStrategyRemoveOldest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
@@ -309,9 +309,9 @@ class IsolateQueueStrategyRemoveOldest<R, P> extends IsolateQueueStrategy<R, P> 
   }
 }
 
-class IsolateQueueStrategyDiscardIncoming<R, P> extends IsolateQueueStrategy<R, P> {
+class QueueStrategyDiscardIncoming<R, P> extends QueueStrategy<R, P> {
   /// Discard the new incoming computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyDiscardIncoming({super.maxCount = 0,});
+  QueueStrategyDiscardIncoming({super.maxCount = 0,});
 
   @override
   bool continueIfMaxCountExceeded() {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
   - [Basic Usage](#basic-usage)
   - [Custom Function Usage](#custom-function-usage)
   - [Progress Values (Receives multiple values from a single `compute`)](#progress-values)
+- [Strategy Of The Queue](#strategy-of-the-queue)
+  - [Control how a new computation is added to the Queue](#control-how-a-new-computation-is-added-to-the-queue)
+  - [Compute a priority computation](#compute-a-priority-computation)
 - [Try Catch Block](#try-catch-block)
 - [Addtional Information](#additional-information)
 - [Contributions](#contributions)
@@ -248,7 +251,30 @@ final isolateManager = IsolateManager.createCustom(
 
 Now you can use everything as the **Basic Usage**.
 
-## try-catch Block
+## Strategy Of The Queue
+
+### Control how a new computation is added to the Queue
+
+When creating a new `IsolateManager` or `IsolateManagerShared`, you can specify the `queueStrategy` to control the way that a new computation is added or a computation is got from the Queue. There are 3 base strategies:
+
+```dart
+/// Remove the newest computation if the [maxCount] is exceeded (default).
+IsolateQueueStrategyRemoveNewest();
+
+/// Remove the oldest computation if the [maxCount] is exceeded.
+IsolateQueueStrategyRemoveOldest()
+
+/// Discard the new incoming computation if the [maxCount] is exceeded.
+IsolateQueueStrategyDiscardIncoming()
+```
+
+You can set the `maxCount` (the max number of the queued computations) of an `IsolateManager` or `IsolateManagerShared`, if this value is <= 0, the number of queues is unlimited.
+
+### Compute a priority computation
+
+When you have a computation that you want to compute as soon as possible, you can change the `priority` parameter to `true` to promote it to the top of the Queue.
+
+## Try-Catch Block
 
 You can use `try-catch` to catch exceptions:
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,49 @@ You can set the `maxCount` (the max number of the queued computations) of an `Is
 
 When you have a computation that you want to compute as soon as possible, you can change the `priority` parameter to `true` to promote it to the top of the Queue.
 
+### Create a custom strategy
+
+You can extend the `IsolateQueueStrategy` to create your own strategy. For instances:
+
+```dart
+class IsolateQueueStrategyRemoveNewest<R, P> extends IsolateQueueStrategy<R, P> {
+  /// Remove the newest computation if the [maxCount] is exceeded.
+  IsolateQueueStrategyRemoveNewest({super.maxCount = 0});
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    // Remove the last computation if the Queue (mean the newest one).
+    _queues.removeLast();
+    // It means the current computation should be added to the Queue.
+    return true; 
+  }
+}
+
+class IsolateQueueStrategyRemoveOldest<R, P> extends IsolateQueueStrategy<R, P> {
+  /// Remove the oldest computation if the [maxCount] is exceeded.
+  IsolateQueueStrategyRemoveOldest({super.maxCount = 0});
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    // Remove the first computation if the Queue (mean the oldest one).
+    _queues.removeFirst();
+    // It means the current computation should be added to the Queue.
+    return true;
+  }
+}
+
+class IsolateQueueStrategyDiscardIncoming<R, P> extends IsolateQueueStrategy<R, P> {
+  /// Discard the new incoming computation if the [maxCount] is exceeded.
+  IsolateQueueStrategyDiscardIncoming({super.maxCount = 0,});
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    // It means the current computation should NOT be added to the Queue.
+    return false;
+  }
+}
+```
+
 ## Try-Catch Block
 
 You can use `try-catch` to catch exceptions:

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@
   - [Custom Function Usage](#custom-function-usage)
   - [Progress Values (Receives multiple values from a single `compute`)](#progress-values)
 - [Strategy Of The Queue](#strategy-of-the-queue)
-  - [Control how a new computation is added to the Queue](#control-how-a-new-computation-is-added-to-the-queue)
   - [Compute a priority computation](#compute-a-priority-computation)
+  - [Max number of Queues](#max-number-of-queues)
+  - [How a new computation is added if the max queues is exceeded](#how-a-new-computation-is-added-if-the-max-queues-is-exceeded)
 - [Try Catch Block](#try-catch-block)
+- [The Generator Options And Flags](#the-generator-options-and-flags)
 - [Addtional Information](#additional-information)
 - [Contributions](#contributions)
 
@@ -253,7 +255,15 @@ Now you can use everything as the **Basic Usage**.
 
 ## Strategy Of The Queue
 
-### Control how a new computation is added to the Queue
+### Compute a priority computation
+
+When you have a computation that you want to compute as soon as possible, you can change the `priority` parameter to `true` to promote it to the top of the Queue.
+
+### Max number of Queues
+
+You can set the `maxCount` (the max number of the queued computations) of an `IsolateManager` or `IsolateManagerShared`, if this value is <= 0, the number of queues is unlimited.
+
+### How a new computation is added if the max queues is exceeded
 
 When creating a new `IsolateManager` or `IsolateManagerShared`, you can specify the `queueStrategy` to control the way that a new computation is added or a computation is got from the Queue. There are 3 base strategies:
 
@@ -267,12 +277,6 @@ IsolateQueueStrategyRemoveOldest()
 /// Discard the new incoming computation if the [maxCount] is exceeded.
 IsolateQueueStrategyDiscardIncoming()
 ```
-
-You can set the `maxCount` (the max number of the queued computations) of an `IsolateManager` or `IsolateManagerShared`, if this value is <= 0, the number of queues is unlimited.
-
-### Compute a priority computation
-
-When you have a computation that you want to compute as soon as possible, you can change the `priority` parameter to `true` to promote it to the top of the Queue.
 
 ### Create a custom strategy
 
@@ -380,6 +384,20 @@ void progressFunction(dynamic params) {
 }
 ```
 
+## The Generator Options And Flags
+
+- `--single`: Generates single Functions only.
+- `--shared`: Generates shared Functions only.
+- `--in <path>` (or `-i <path>`): Inputted folder.
+- `--out <path>` (or `-o <path>`): Outputted folder.
+- `--obfuscate <level>`: The obfuscated level of JS (0 to 4). The default is set to `4`.
+- `--debug`: Keeps the temp files for debugging.
+- If you want to add options or flags to the Dart to Js Compiler, you can add a `--` flag before adding those options and flags. Please note that all the arguments after the `--` flag will be passed directly into the Dart to Js Compiler. For instance:
+
+  ```shell
+  dart run isolate_manager:generate --single -i test -out test -- -Dkey1=value1 -Dkey2=value2
+  ```
+
 ## Additional Information
 
 - Use `queuesLength` to get the current number of queued computation.
@@ -433,21 +451,6 @@ void progressFunction(dynamic params) {
       ```
 
   **Data flow:** Main -> Isolate or Worker -> **Converter** -> Result
-
-- If you want to use Worker more effectively, convert all parameters and results to JSON (or String) before sending them.
-
-- The generator options and flags:
-  - `--single`: Generates single Functions only.
-  - `--shared`: Generates shared Functions only.
-  - `--in <path>` (or `-i <path>`): Inputted folder.
-  - `--out <path>` (or `-o <path>`): Outputted folder.
-  - `--obfuscate <level>`: The obfuscated level of JS (0 to 4). Default is set to `4`.
-  - `--debug`: Keeps the temp files for debugging.
-  - If you want to add options or flags to the Dart to Js Compiler, you can add a `--` flag before adding those options and flags. Please note that all the arguments after the `--` flag will be passed directly into the Dart to Js Compiler. For instance:
-
-    ```shell
-    dart run isolate_manager:generate --single -i test -out test -- -Dkey1=value1 -Dkey2=value2
-    ```
 
 - All above examples use `top-level` functions so the `workerName` will be the same as the function name. If you use `static` functions, you have to add the class name like `ClassName.functionName` to the `workerName` parameter. For instance:
 

--- a/lib/isolate_manager.dart
+++ b/lib/isolate_manager.dart
@@ -10,4 +10,4 @@ export 'src/isolate_manager_controller.dart';
 export 'src/isolate_manager_function.dart';
 export 'src/models/isolate_manager_shared_worker.dart';
 export 'src/models/isolate_manager_worker.dart';
-export 'src/models/isolate_queue_strategy.dart';
+export 'src/models/queue_strategy.dart';

--- a/lib/isolate_manager.dart
+++ b/lib/isolate_manager.dart
@@ -10,3 +10,4 @@ export 'src/isolate_manager_controller.dart';
 export 'src/isolate_manager_function.dart';
 export 'src/models/isolate_manager_shared_worker.dart';
 export 'src/models/isolate_manager_worker.dart';
+export 'src/models/isolate_queue_strategy.dart';

--- a/lib/src/base/shared/function.dart
+++ b/lib/src/base/shared/function.dart
@@ -22,6 +22,7 @@ Future<R> platformExecute<R extends Object, P extends Object>({
   required P params,
   required String? workerFunction,
   required Object? workerParams,
+  required bool priority,
 }) async {
   return platformExecuteImpl<R, P>(
     manager: manager,
@@ -29,6 +30,7 @@ Future<R> platformExecute<R extends Object, P extends Object>({
     params: params,
     workerFunction: workerFunction,
     workerParams: workerParams,
+    priority: priority,
   );
 }
 

--- a/lib/src/base/shared/isolate_manager_shared.dart
+++ b/lib/src/base/shared/isolate_manager_shared.dart
@@ -58,7 +58,7 @@ class IsolateManagerShared {
           workerName: useWorker ? join(subPath, kSharedWorkerName) : '',
           workerConverter: workerConverter,
           concurrent: concurrent,
-          isolateQueueStrategy: queueStrategy,
+          queueStrategy: queueStrategy,
           isDebug: isDebug,
         ) {
     if (autoStart) start();

--- a/lib/src/base/shared/isolate_manager_shared.dart
+++ b/lib/src/base/shared/isolate_manager_shared.dart
@@ -51,7 +51,7 @@ class IsolateManagerShared {
     this.workerMappings = const {},
     bool autoStart = true,
     String subPath = '',
-    IsolateQueueStrategy<Object, List<Object>>? queueStrategy,
+    QueueStrategy<Object, List<Object>>? queueStrategy,
     bool isDebug = false,
   }) : _manager = IsolateManager.create(
           internalFunction,

--- a/lib/src/base/shared/isolate_manager_shared.dart
+++ b/lib/src/base/shared/isolate_manager_shared.dart
@@ -51,12 +51,14 @@ class IsolateManagerShared {
     this.workerMappings = const {},
     bool autoStart = true,
     String subPath = '',
+    IsolateQueueStrategy<Object, List<Object>>? queueStrategy,
     bool isDebug = false,
   }) : _manager = IsolateManager.create(
           internalFunction,
           workerName: useWorker ? join(subPath, kSharedWorkerName) : '',
           workerConverter: workerConverter,
           concurrent: concurrent,
+          isolateQueueStrategy: queueStrategy,
           isDebug: isDebug,
         ) {
     if (autoStart) start();
@@ -75,12 +77,14 @@ class IsolateManagerShared {
     P params, {
     String? workerFunction,
     Object? workerParams,
+    bool priority = false,
   }) {
     return _excute(
       function,
       params,
       workerFunction: workerFunction,
       workerParams: workerParams,
+      priority: priority,
     );
   }
 
@@ -95,12 +99,14 @@ class IsolateManagerShared {
     P params, {
     String? workerFunction,
     Object? workerParams,
+    bool priority = false,
   }) {
     return _excute(
       function,
       params,
       workerFunction: workerFunction,
       workerParams: workerParams,
+      priority: priority,
     );
   }
 
@@ -110,6 +116,7 @@ class IsolateManagerShared {
     P params, {
     String? workerFunction,
     Object? workerParams,
+    bool priority = false,
   }) async {
     return platformExecute<R, P>(
       manager: _manager,
@@ -117,6 +124,7 @@ class IsolateManagerShared {
       params: params,
       workerFunction: workerFunction ?? workerMappings[function],
       workerParams: workerParams,
+      priority: priority,
     );
   }
 

--- a/lib/src/base/shared/isolate_manager_shared.dart
+++ b/lib/src/base/shared/isolate_manager_shared.dart
@@ -43,6 +43,13 @@ class IsolateManagerShared {
   /// If the generated Worker is put inside a folder (such as `workers`), the [subPath]
   /// needs to be set to `workers`.
   ///
+  /// Control the Queue strategy via [queueStrategy] with the following basic
+  /// strategies:
+  ///   - [QueueStrategyUnlimited] - default.
+  ///   - [QueueStrategyRemoveNewest]
+  ///   - [QueueStrategyRemoveOldest]
+  ///   - [QueueStrategyDiscardIncoming]
+  ///
   /// Set [isDebug] to `true` if you want to print the debug log.
   IsolateManagerShared({
     int concurrent = 1,

--- a/lib/src/base/shared/platforms/stub.dart
+++ b/lib/src/base/shared/platforms/stub.dart
@@ -9,8 +9,9 @@ Future<R> platformExecuteImpl<R extends Object, P extends Object>({
   required P params,
   required String? workerFunction,
   required Object? workerParams,
+  required bool priority,
 }) async {
-  return (await manager.compute([function, params])) as R;
+  return (await manager.compute([function, params], priority: priority)) as R;
 }
 
 /// Create a Worker on Web.

--- a/lib/src/base/shared/platforms/web.dart
+++ b/lib/src/base/shared/platforms/web.dart
@@ -11,6 +11,7 @@ Future<R> platformExecuteImpl<R extends Object, P extends Object>({
   required P params,
   required String? workerFunction,
   required Object? workerParams,
+  required bool priority,
 }) async {
   final isWorker = manager.workerName != '';
   final isDebug = manager.isDebug;
@@ -19,14 +20,9 @@ Future<R> platformExecuteImpl<R extends Object, P extends Object>({
         'so `Future` will be used instead');
   }
 
-  if (isWorker && workerFunction != null) {
-    final finalParams = workerParams ?? params;
-    return (await manager.compute([workerFunction, finalParams])) as R;
-  } else {
-    final completer = Completer<R>();
-    completer.complete(function(params));
-    return completer.future;
-  }
+  final func = (isWorker && workerFunction != null) ? workerFunction : function;
+  final finalParams = workerParams ?? params;
+  return (await manager.compute([func, finalParams], priority: priority)) as R;
 }
 
 /// Create a Worker on Web.

--- a/lib/src/isolate_manager.dart
+++ b/lib/src/isolate_manager.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:isolate_manager/src/models/isolate_queue_strategy.dart';
+import 'package:isolate_manager/src/models/queue_strategy.dart';
 
 import 'base/isolate_contactor.dart';
 import 'base/isolate_manager_shared.dart';
@@ -59,7 +59,7 @@ class IsolateManager<R, P> {
   int get queuesLength => isolateQueueStrategy.queuesCount;
 
   /// Strategy to control a new (incoming) computation.
-  final IsolateQueueStrategy<R, P> isolateQueueStrategy;
+  final QueueStrategy<R, P> isolateQueueStrategy;
 
   /// If you want to call the [start] method manually without `await`, you can `await`
   /// later by using [ensureStarted] to ensure that all the isolates are started.
@@ -75,12 +75,12 @@ class IsolateManager<R, P> {
     this.concurrent = 1,
     this.converter,
     this.workerConverter,
-    IsolateQueueStrategy<R, P>? isolateQueueStrategy,
+    QueueStrategy<R, P>? isolateQueueStrategy,
     this.isDebug = false,
   })  : isCustomIsolate = false,
         initialParams = '',
         isolateQueueStrategy =
-            isolateQueueStrategy ?? IsolateQueueStrategyRemoveOldest() {
+            isolateQueueStrategy ?? QueueStrategyRemoveOldest() {
     // Set the debug log prefix.
     IsolateContactor.debugLogPrefix = debugLogPrefix;
   }
@@ -93,11 +93,11 @@ class IsolateManager<R, P> {
     this.concurrent = 1,
     this.converter,
     this.workerConverter,
-    IsolateQueueStrategy<R, P>? isolateQueueStrategy,
+    QueueStrategy<R, P>? isolateQueueStrategy,
     this.isDebug = false,
   })  : isCustomIsolate = true,
         isolateQueueStrategy =
-            isolateQueueStrategy ?? IsolateQueueStrategyRemoveOldest() {
+            isolateQueueStrategy ?? QueueStrategyRemoveOldest() {
     // Set the debug log prefix.
     IsolateContactor.debugLogPrefix = debugLogPrefix;
   }
@@ -131,7 +131,7 @@ class IsolateManager<R, P> {
     bool autoStart = true,
     String subPath = '',
     int maxQueueCount = 0,
-    IsolateQueueStrategy<Object, List<Object>>? queueStrategy,
+    QueueStrategy<Object, List<Object>>? queueStrategy,
     bool isDebug = false,
   }) =>
       IsolateManagerShared(

--- a/lib/src/isolate_manager.dart
+++ b/lib/src/isolate_manager.dart
@@ -131,7 +131,7 @@ class IsolateManager<R, P> {
     bool autoStart = true,
     String subPath = '',
     int maxQueueCount = 0,
-    IsolateQueueStrategy<Object, List<Object>>? isolateStrategy,
+    IsolateQueueStrategy<Object, List<Object>>? queueStrategy,
     bool isDebug = false,
   }) =>
       IsolateManagerShared(
@@ -141,7 +141,7 @@ class IsolateManager<R, P> {
         workerMappings: workerMappings,
         autoStart: autoStart,
         subPath: subPath,
-        queueStrategy: isolateStrategy,
+        queueStrategy: queueStrategy,
         isDebug: isDebug,
       );
 

--- a/lib/src/isolate_manager.dart
+++ b/lib/src/isolate_manager.dart
@@ -132,6 +132,7 @@ class IsolateManager<R, P> {
   ///   - [QueueStrategyRemoveNewest]
   ///   - [QueueStrategyRemoveOldest]
   ///   - [QueueStrategyDiscardIncoming]
+  ///
   /// Set [isDebug] to `true` if you want to print the debug log.
   static IsolateManagerShared createShared({
     int concurrent = 1,

--- a/lib/src/models/isolate_queue_strategy.dart
+++ b/lib/src/models/isolate_queue_strategy.dart
@@ -67,7 +67,7 @@ abstract class IsolateQueueStrategy<R, P> {
 
 class IsolateQueueStrategyRemoveNewest<R, P>
     extends IsolateQueueStrategy<R, P> {
-  /// Remove the first (newest) computation if the [maxQueueCount] is exceeded.
+  /// Remove the newest computation if the [maxCount] is exceeded.
   IsolateQueueStrategyRemoveNewest({
     super.maxCount = 0,
   });
@@ -81,7 +81,7 @@ class IsolateQueueStrategyRemoveNewest<R, P>
 
 class IsolateQueueStrategyRemoveOldest<R, P>
     extends IsolateQueueStrategy<R, P> {
-  /// Remove the last (oldest) computation if the [maxQueueCount] is exceeded.
+  /// Remove the oldest computation if the [maxCount] is exceeded.
   IsolateQueueStrategyRemoveOldest({
     super.maxCount = 0,
   });
@@ -95,7 +95,7 @@ class IsolateQueueStrategyRemoveOldest<R, P>
 
 class IsolateQueueStrategyDiscardIncoming<R, P>
     extends IsolateQueueStrategy<R, P> {
-  /// Discard the new incoming computation if the [maxQueueCount] is exceeded.
+  /// Discard the new incoming computation if the [maxCount] is exceeded.
   IsolateQueueStrategyDiscardIncoming({
     super.maxCount = 0,
   });

--- a/lib/src/models/isolate_queue_strategy.dart
+++ b/lib/src/models/isolate_queue_strategy.dart
@@ -68,13 +68,13 @@ abstract class IsolateQueueStrategy<R, P> {
 class IsolateQueueStrategyRemoveNewest<R, P>
     extends IsolateQueueStrategy<R, P> {
   /// Remove the newest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveNewest({
-    super.maxCount = 0,
-  });
+  IsolateQueueStrategyRemoveNewest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
+    // Remove the last computation if the Queue (mean the newest one).
     _queues.removeLast();
+    // It means the current computation should be added to the Queue.
     return true;
   }
 }
@@ -82,13 +82,13 @@ class IsolateQueueStrategyRemoveNewest<R, P>
 class IsolateQueueStrategyRemoveOldest<R, P>
     extends IsolateQueueStrategy<R, P> {
   /// Remove the oldest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveOldest({
-    super.maxCount = 0,
-  });
+  IsolateQueueStrategyRemoveOldest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
+    // Remove the first computation if the Queue (mean the oldest one).
     _queues.removeFirst();
+    // It means the current computation should be added to the Queue.
     return true;
   }
 }
@@ -102,6 +102,7 @@ class IsolateQueueStrategyDiscardIncoming<R, P>
 
   @override
   bool continueIfMaxCountExceeded() {
+    // It means the current computation should NOT be added to the Queue.
     return false;
   }
 }

--- a/lib/src/models/isolate_queue_strategy.dart
+++ b/lib/src/models/isolate_queue_strategy.dart
@@ -1,0 +1,107 @@
+import 'dart:collection';
+
+import 'package:isolate_manager/src/models/isolate_queue.dart';
+
+/// Strategy to control a new (incoming) computation if the maximum number of Queues
+/// is reached.
+///
+/// Some of strategies:
+///   - [IsolateQueueStrategyRemoveNewest] is default.
+///   - [IsolateQueueStrategyRemoveOldest]
+///   - [IsolateQueueStrategyDiscardIncoming]
+abstract class IsolateQueueStrategy<R, P> {
+  /// Queue of isolates.
+  final Queue<IsolateQueue<R, P>> _queues = Queue();
+
+  /// Max number of queued computations.
+  ///
+  /// If this value <= 0, the number of queues is unlimited (default).
+  final int maxCount;
+
+  /// Number of the current queues.
+  int get queuesCount => _queues.length;
+
+  /// Strategy to control a new (incoming) computation if the maximum number of Queues
+  /// is reached. The maximum number is unlimited if [maxCount] <= 0 (by default).
+  ///
+  /// Some of strategies:
+  ///   - [IsolateQueueStrategyRemoveNewest] is default.
+  ///   - [IsolateQueueStrategyRemoveOldest]
+  ///   - [IsolateQueueStrategyDiscardIncoming]
+  IsolateQueueStrategy({this.maxCount = 0});
+
+  /// Run this method before adding a new computation to the Queue if the max
+  /// queue count is exceeded. If this method returns `false`, the new computation
+  /// will not be added to the Queue.
+  bool continueIfMaxCountExceeded();
+
+  /// Add a new computation to the Queue.
+  ///
+  /// If [addToTop] is `true`, the new computation will be added to the top of the
+  /// Queue.
+  void add(IsolateQueue<R, P> queue, {bool addToTop = false}) {
+    if (maxCount > 0 && queuesCount >= maxCount) {
+      if (!continueIfMaxCountExceeded()) return;
+    }
+    if (addToTop) {
+      _queues.addFirst(queue);
+    } else {
+      _queues.add(queue);
+    }
+  }
+
+  /// Check if the Queue is not empty.
+  bool hasNext() {
+    return _queues.isNotEmpty;
+  }
+
+  /// Get the next computation.
+  IsolateQueue<R, P> getNext() {
+    assert(hasNext());
+    return _queues.removeFirst();
+  }
+
+  /// Clear all queues.
+  void clear() => _queues.clear();
+}
+
+class IsolateQueueStrategyRemoveNewest<R, P>
+    extends IsolateQueueStrategy<R, P> {
+  /// Remove the first (newest) computation if the [maxQueueCount] is exceeded.
+  IsolateQueueStrategyRemoveNewest({
+    super.maxCount = 0,
+  });
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    _queues.removeLast();
+    return true;
+  }
+}
+
+class IsolateQueueStrategyRemoveOldest<R, P>
+    extends IsolateQueueStrategy<R, P> {
+  /// Remove the last (oldest) computation if the [maxQueueCount] is exceeded.
+  IsolateQueueStrategyRemoveOldest({
+    super.maxCount = 0,
+  });
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    _queues.removeFirst();
+    return true;
+  }
+}
+
+class IsolateQueueStrategyDiscardIncoming<R, P>
+    extends IsolateQueueStrategy<R, P> {
+  /// Discard the new incoming computation if the [maxQueueCount] is exceeded.
+  IsolateQueueStrategyDiscardIncoming({
+    super.maxCount = 0,
+  });
+
+  @override
+  bool continueIfMaxCountExceeded() {
+    return false;
+  }
+}

--- a/lib/src/models/queue_strategy.dart
+++ b/lib/src/models/queue_strategy.dart
@@ -6,7 +6,8 @@ import 'package:isolate_manager/src/models/isolate_queue.dart';
 /// is reached.
 ///
 /// Some of strategies:
-///   - [QueueStrategyRemoveNewest] is default.
+///   - [QueueStrategyUnlimited] - is default.
+///   - [QueueStrategyRemoveNewest]
 ///   - [QueueStrategyRemoveOldest]
 ///   - [QueueStrategyDiscardIncoming]
 abstract class QueueStrategy<R, P> {
@@ -25,7 +26,8 @@ abstract class QueueStrategy<R, P> {
   /// is reached. The maximum number is unlimited if [maxCount] <= 0 (by default).
   ///
   /// Some of strategies:
-  ///   - [QueueStrategyRemoveNewest] is default.
+  ///   - [QueueStrategyUnlimited] is default.
+  ///   - [QueueStrategyRemoveNewest]
   ///   - [QueueStrategyRemoveOldest]
   ///   - [QueueStrategyDiscardIncoming]
   QueueStrategy({this.maxCount = 0});
@@ -63,6 +65,14 @@ abstract class QueueStrategy<R, P> {
 
   /// Clear all queues.
   void clear() => _queues.clear();
+}
+
+class QueueStrategyUnlimited<R, P> extends QueueStrategy<R, P> {
+  /// Unlimited queued computations.
+  QueueStrategyUnlimited();
+
+  @override
+  bool continueIfMaxCountExceeded() => true;
 }
 
 class QueueStrategyRemoveNewest<R, P> extends QueueStrategy<R, P> {

--- a/lib/src/models/queue_strategy.dart
+++ b/lib/src/models/queue_strategy.dart
@@ -6,10 +6,10 @@ import 'package:isolate_manager/src/models/isolate_queue.dart';
 /// is reached.
 ///
 /// Some of strategies:
-///   - [IsolateQueueStrategyRemoveNewest] is default.
-///   - [IsolateQueueStrategyRemoveOldest]
-///   - [IsolateQueueStrategyDiscardIncoming]
-abstract class IsolateQueueStrategy<R, P> {
+///   - [QueueStrategyRemoveNewest] is default.
+///   - [QueueStrategyRemoveOldest]
+///   - [QueueStrategyDiscardIncoming]
+abstract class QueueStrategy<R, P> {
   /// Queue of isolates.
   final Queue<IsolateQueue<R, P>> _queues = Queue();
 
@@ -25,10 +25,10 @@ abstract class IsolateQueueStrategy<R, P> {
   /// is reached. The maximum number is unlimited if [maxCount] <= 0 (by default).
   ///
   /// Some of strategies:
-  ///   - [IsolateQueueStrategyRemoveNewest] is default.
-  ///   - [IsolateQueueStrategyRemoveOldest]
-  ///   - [IsolateQueueStrategyDiscardIncoming]
-  IsolateQueueStrategy({this.maxCount = 0});
+  ///   - [QueueStrategyRemoveNewest] is default.
+  ///   - [QueueStrategyRemoveOldest]
+  ///   - [QueueStrategyDiscardIncoming]
+  QueueStrategy({this.maxCount = 0});
 
   /// Run this method before adding a new computation to the Queue if the max
   /// queue count is exceeded. If this method returns `false`, the new computation
@@ -65,10 +65,9 @@ abstract class IsolateQueueStrategy<R, P> {
   void clear() => _queues.clear();
 }
 
-class IsolateQueueStrategyRemoveNewest<R, P>
-    extends IsolateQueueStrategy<R, P> {
+class QueueStrategyRemoveNewest<R, P> extends QueueStrategy<R, P> {
   /// Remove the newest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveNewest({super.maxCount = 0});
+  QueueStrategyRemoveNewest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
@@ -79,10 +78,9 @@ class IsolateQueueStrategyRemoveNewest<R, P>
   }
 }
 
-class IsolateQueueStrategyRemoveOldest<R, P>
-    extends IsolateQueueStrategy<R, P> {
+class QueueStrategyRemoveOldest<R, P> extends QueueStrategy<R, P> {
   /// Remove the oldest computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyRemoveOldest({super.maxCount = 0});
+  QueueStrategyRemoveOldest({super.maxCount = 0});
 
   @override
   bool continueIfMaxCountExceeded() {
@@ -93,10 +91,9 @@ class IsolateQueueStrategyRemoveOldest<R, P>
   }
 }
 
-class IsolateQueueStrategyDiscardIncoming<R, P>
-    extends IsolateQueueStrategy<R, P> {
+class QueueStrategyDiscardIncoming<R, P> extends QueueStrategy<R, P> {
   /// Discard the new incoming computation if the [maxCount] is exceeded.
-  IsolateQueueStrategyDiscardIncoming({
+  QueueStrategyDiscardIncoming({
     super.maxCount = 0,
   });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isolate_manager
 description: Create multiple long-lived isolates for the Functions, supports Worker on the Web (with the effective generator) and WASM compilation.
-version: 5.3.0
+version: 5.4.0
 homepage: https://github.com/lamnhan066/isolate_manager
 
 topics:

--- a/test/isolate_manager_test.dart
+++ b/test/isolate_manager_test.dart
@@ -435,11 +435,12 @@ void main() {
 
   group('Isolate Queue Strategy -', () {
     test('QueueStrategyRemoveNewest with unlimited queue count', () {
-      final queueStrategies = QueueStrategyRemoveNewest<int, int>();
+      final queueStrategies = QueueStrategyUnlimited<int, int>();
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null));
       }
       expect(queueStrategies.queuesCount, equals(10));
+      expect(queueStrategies.continueIfMaxCountExceeded(), true);
       List result = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
       while (queueStrategies.hasNext()) {
         expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
@@ -448,7 +449,7 @@ void main() {
     });
 
     test('QueueStrategyRemoveNewest with addToTop is true', () {
-      final queueStrategies = QueueStrategyRemoveNewest<int, int>();
+      final queueStrategies = QueueStrategyUnlimited<int, int>();
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
       }

--- a/test/isolate_manager_test.dart
+++ b/test/isolate_manager_test.dart
@@ -434,8 +434,8 @@ void main() {
   });
 
   group('Isolate Queue Strategy -', () {
-    test('IsolateQueueStrategyRemoveNewest with unlimited queue count', () {
-      final queueStrategies = IsolateQueueStrategyRemoveNewest<int, int>();
+    test('QueueStrategyRemoveNewest with unlimited queue count', () {
+      final queueStrategies = QueueStrategyRemoveNewest<int, int>();
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null));
       }
@@ -447,8 +447,8 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyRemoveNewest with addToTop is true', () {
-      final queueStrategies = IsolateQueueStrategyRemoveNewest<int, int>();
+    test('QueueStrategyRemoveNewest with addToTop is true', () {
+      final queueStrategies = QueueStrategyRemoveNewest<int, int>();
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
       }
@@ -460,9 +460,8 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyRemoveNewest', () {
-      final queueStrategies =
-          IsolateQueueStrategyRemoveNewest<int, int>(maxCount: 3);
+    test('QueueStrategyRemoveNewest', () {
+      final queueStrategies = QueueStrategyRemoveNewest<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null));
       }
@@ -474,9 +473,8 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyRemoveNewest with addToTop is true', () {
-      final queueStrategies =
-          IsolateQueueStrategyRemoveNewest<int, int>(maxCount: 3);
+    test('QueueStrategyRemoveNewest with addToTop is true', () {
+      final queueStrategies = QueueStrategyRemoveNewest<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
       }
@@ -488,9 +486,8 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyRemoveOldest', () {
-      final queueStrategies =
-          IsolateQueueStrategyRemoveOldest<int, int>(maxCount: 3);
+    test('QueueStrategyRemoveOldest', () {
+      final queueStrategies = QueueStrategyRemoveOldest<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null));
       }
@@ -502,9 +499,8 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyRemoveOldest with addToTop is true', () {
-      final queueStrategies =
-          IsolateQueueStrategyRemoveOldest<int, int>(maxCount: 3);
+    test('QueueStrategyRemoveOldest with addToTop is true', () {
+      final queueStrategies = QueueStrategyRemoveOldest<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
       }
@@ -516,9 +512,9 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyDiscardIncoming', () {
+    test('QueueStrategyDiscardIncoming', () {
       final queueStrategies =
-          IsolateQueueStrategyDiscardIncoming<int, int>(maxCount: 3);
+          QueueStrategyDiscardIncoming<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null));
       }
@@ -530,9 +526,9 @@ void main() {
       expect(result.length, equals(0));
     });
 
-    test('IsolateQueueStrategyDiscardIncoming with addToTop is true', () {
+    test('QueueStrategyDiscardIncoming with addToTop is true', () {
       final queueStrategies =
-          IsolateQueueStrategyDiscardIncoming<int, int>(maxCount: 3);
+          QueueStrategyDiscardIncoming<int, int>(maxCount: 3);
       for (int i = 0; i < 10; i++) {
         queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
       }

--- a/test/isolate_manager_test.dart
+++ b/test/isolate_manager_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:isolate_manager/isolate_manager.dart';
+import 'package:isolate_manager/src/models/isolate_queue.dart';
 import 'package:test/test.dart';
 
 //  dart run isolate_manager:generate -i test -o test
@@ -430,6 +431,118 @@ void main() {
     final result = await isolate.compute(jsonEncode(map));
 
     expect(jsonDecode(result), map);
+  });
+
+  group('Isolate Queue Strategy -', () {
+    test('IsolateQueueStrategyRemoveNewest with unlimited queue count', () {
+      final queueStrategies = IsolateQueueStrategyRemoveNewest<int, int>();
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null));
+      }
+      expect(queueStrategies.queuesCount, equals(10));
+      List result = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyRemoveNewest with addToTop is true', () {
+      final queueStrategies = IsolateQueueStrategyRemoveNewest<int, int>();
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
+      }
+      expect(queueStrategies.queuesCount, equals(10));
+      final result = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].reversed.toList();
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyRemoveNewest', () {
+      final queueStrategies =
+          IsolateQueueStrategyRemoveNewest<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null));
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [0, 1, 9];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyRemoveNewest with addToTop is true', () {
+      final queueStrategies =
+          IsolateQueueStrategyRemoveNewest<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [9, 8, 7];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyRemoveOldest', () {
+      final queueStrategies =
+          IsolateQueueStrategyRemoveOldest<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null));
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [7, 8, 9];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyRemoveOldest with addToTop is true', () {
+      final queueStrategies =
+          IsolateQueueStrategyRemoveOldest<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [9, 1, 0];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyDiscardIncoming', () {
+      final queueStrategies =
+          IsolateQueueStrategyDiscardIncoming<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null));
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [0, 1, 2];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
+
+    test('IsolateQueueStrategyDiscardIncoming with addToTop is true', () {
+      final queueStrategies =
+          IsolateQueueStrategyDiscardIncoming<int, int>(maxCount: 3);
+      for (int i = 0; i < 10; i++) {
+        queueStrategies.add(IsolateQueue<int, int>(i, null), addToTop: true);
+      }
+      expect(queueStrategies.queuesCount, equals(3));
+      List result = [2, 1, 0];
+      while (queueStrategies.hasNext()) {
+        expect(queueStrategies.getNext().params, equals(result.removeAt(0)));
+      }
+      expect(result.length, equals(0));
+    });
   });
 }
 


### PR DESCRIPTION
Control the maximum of the queued computation and how a new computation is added. Able to compute a priority computation (promote a computation to the top of the Queue).

Fixes #28 #24 