### PR TITLE
[Feat] Auto generate the worker mappings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Compile Workers
         run: |
-          dart run isolate_manager:generate -i test -o test
+          dart run isolate_manager:generate -i test -o test --worker-mappings-experiment=test/isolate_manager_test.dart
+          dart run isolate_manager:generate -i test -o test --worker-mappings-experiment=test/isolate_manager_shared_test.dart
           dart run isolate_manager:generate -i test -o test/workers
 
       - name: Run tests on VM

--- a/README.md
+++ b/README.md
@@ -476,6 +476,12 @@ void progressFunction(dynamic params) {
   dart run isolate_manager:generate --single -i test -out test -- -Dkey1=value1 -Dkey2=value2
   ```
 
+- **[Experiment]**: Automatically generate the `workerMappings` for both `IsolateManager` and `IsolateManagerShared` by adding a `--worker-mappings-experiment=lib/main.dart` flag to the generator. Here are the steps of the generator:
+
+  1. Generate a `_addWorkerMappings` method at the end of the `lib/main.dart`.
+  2. Add all worker mappings by using `IsolateManager.addWorkerMapping` method.
+  3. Add the `_addWorkerMappings` method to the beginning of the `main` method.
+
 ## Additional Information
 
 - Use `queuesLength` to get the current number of queued computation.

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:isolate_manager/isolate_manager.dart';
+import 'package:path/path.dart';
 
 import 'generate_shared.dart' as shared;
 import 'generate_single.dart' as single;
@@ -61,6 +64,12 @@ void main(List<String> args) async {
       'wasm',
       defaultsTo: false,
       help: 'Compile to wasm',
+    )
+    ..addOption(
+      'worker-mappings-experiment',
+      defaultsTo: '',
+      help:
+          '[Experiment] Generate the `workerMappings` and add it to the `main` app automatically',
     );
 
   final argResults = parser.parse(args);
@@ -84,4 +93,127 @@ void main(List<String> args) async {
     await shared.generate(argResults, dartArgs);
     print('>> Generated.');
   }
+}
+
+void printDebug(Object? Function() log) {
+  print(log());
+}
+
+Future<void> addWorkerMappingToSourceFile(
+  String workerMappingsPath,
+  String sourceFilePath,
+  String functionName,
+) async {
+  final mainPath = workerMappingsPath.isNotEmpty
+      ? absolute(workerMappingsPath)
+      : absolute('lib/main.dart');
+
+  final file = File(mainPath);
+  if (!file.existsSync()) {
+    printDebug(() => 'Source file does not exist: $mainPath');
+    return;
+  }
+
+  // Read the existing content of the file.
+  final content = await file.readAsLines();
+
+  // Step 1: Add the import statements.
+  var lastImportIndex = -1;
+  for (var i = 0; i < content.length; i++) {
+    if (content[i].startsWith('import ')) {
+      lastImportIndex = i;
+    }
+  }
+
+  const newImportLine =
+      "import 'package:isolate_manager/isolate_manager.dart';";
+  final newFunctionSourceImport =
+      "import '${relative(sourceFilePath, from: 'lib')}';";
+
+  // Insert the new import line after all existing import statements, if it doesn't exist already.
+  if (!content.contains(newImportLine)) {
+    content.insert(++lastImportIndex, newImportLine);
+  }
+
+  if (!content.contains(newFunctionSourceImport)) {
+    content.insert(++lastImportIndex, newFunctionSourceImport);
+  }
+
+  // Step 2: Find the `main` function and add `addWorkerMappings();` at the beginning.
+  var mainIndex = -1;
+  for (var i = 0; i < content.length; i++) {
+    if (content[i].contains('void main()')) {
+      mainIndex = i;
+      break;
+    }
+  }
+
+  if (mainIndex == -1) {
+    printDebug(() => 'No main function found in the source file.');
+    return;
+  }
+
+  // Find the position after the opening brace of the `main` function.
+  var insertionIndex = mainIndex;
+  while (insertionIndex < content.length &&
+      !content[insertionIndex].contains('{')) {
+    insertionIndex++;
+  }
+
+  if (insertionIndex == content.length) {
+    printDebug(() => 'Malformed main function, no opening brace found.');
+    return;
+  }
+
+  // Add `addWorkerMappings();` if it doesn't already exist.
+  const addWorkerMappingsCall = '  _addWorkerMappings();';
+  var hasAddWorkerMappings = false;
+  for (var i = insertionIndex; i < content.length; i++) {
+    if (content[i].contains('_addWorkerMappings();')) {
+      hasAddWorkerMappings = true;
+      break;
+    }
+  }
+
+  if (!hasAddWorkerMappings) {
+    content.insert(insertionIndex + 1, addWorkerMappingsCall);
+  }
+
+  // Step 3: Collect `IsolateManager.addWorkerMapping` statements and move to `addWorkerMappings` function.
+  final newWorkerMappingLine =
+      "  IsolateManager.addWorkerMapping($functionName, '$functionName');";
+
+  // Step 4: Add or update the `addWorkerMappings` function at the end of the file.
+  final addWorkerMappingsIndex = content
+      .indexWhere((line) => line.contains('void _addWorkerMappings() {'));
+
+  if (addWorkerMappingsIndex == -1) {
+    // If `addWorkerMappings` function does not exist, add it at the end.
+    content
+      ..add('')
+      ..add('void _addWorkerMappings() {')
+      ..add(newWorkerMappingLine)
+      ..add('}');
+  } else {
+    // If `addWorkerMappings` already exists, add the new worker mapping if not already present.
+    var closingBraceIndex = addWorkerMappingsIndex;
+    while (closingBraceIndex < content.length &&
+        !content[closingBraceIndex].contains('}')) {
+      closingBraceIndex++;
+    }
+
+    if (!content
+        .sublist(addWorkerMappingsIndex, closingBraceIndex)
+        .contains(newWorkerMappingLine)) {
+      content.insert(closingBraceIndex, newWorkerMappingLine);
+    }
+  }
+
+  // Write the modified content back to the file.
+  await file.writeAsString(content.join('\n'));
+
+  printDebug(
+    () =>
+        'Updated source file: $sourceFilePath with new import, worker mapping call, and addWorkerMappings function.',
+  );
 }

--- a/lib/src/isolate_manager.dart
+++ b/lib/src/isolate_manager.dart
@@ -109,7 +109,10 @@ class IsolateManager<R, P> {
   /// Add the mapping between a function and a Worker to the [_workerMappings].
   ///
   /// This method is used by the generator.
-  static void addWorkerMapping(Function function, String name) {
+  static void addWorkerMapping<R, P>(
+    IsolateFunction<R, P> function,
+    String name,
+  ) {
     _workerMappings.addAll({function: name});
   }
 

--- a/test/isolate_manager_test.dart
+++ b/test/isolate_manager_test.dart
@@ -5,11 +5,15 @@ import 'package:isolate_manager/isolate_manager.dart';
 import 'package:isolate_manager/src/models/isolate_queue.dart';
 import 'package:test/test.dart';
 
-//  dart run isolate_manager:generate -i test -o test
-//  dart test
-//  dart test --platform=chrome,vm
+/*
+  dart run isolate_manager:generate -i test -o test --single --worker-mappings-experiment=test/isolate_manager_test.dart
+  dart run isolate_manager:generate -i test -o test/workers --single --worker-mappings-experiment=test/isolate_manager_test.dart
+  dart test --platform=vm
+  dart test --platform=chrome
+*/
 
 void main() {
+  _addWorkerMappings();
   group('Models', () {
     test('IsolateState', () {
       for (final state in IsolateState.values) {
@@ -149,7 +153,6 @@ void main() {
     // Create IsolateContactor
     final isolateManager = IsolateManager.create(
       fibonacci,
-      workerName: 'fibonacci',
       concurrent: 4,
     );
 
@@ -352,7 +355,6 @@ void main() {
     final isolateManager = IsolateManager<String, int>.createCustom(
       isolateCallbackSimpleFunctionWithSpecifiedType,
       concurrent: 1,
-      workerName: 'isolateCallbackSimpleFunctionWithSpecifiedType',
     );
     await isolateManager.start();
 
@@ -434,7 +436,6 @@ void main() {
   test('Test a 2D List to 1D List', () async {
     final isolate = IsolateManager.create(
       a2DTo1DList,
-      workerName: 'a2DTo1DList',
     );
     await isolate.start();
 
@@ -450,7 +451,6 @@ void main() {
   test('Test a 1D List to 2D List', () async {
     final isolate = IsolateManager.create(
       a1DTo2DList,
-      workerName: 'a1DTo2DList',
     );
     await isolate.start();
 
@@ -723,4 +723,20 @@ Future<int> errorFunctionFuture(List<int> value) async {
     return throw StateError('The exception is threw at value[0] = ${value[0]}');
   }
   return value[0] + value[1];
+}
+
+void _addWorkerMappings() {
+  IsolateManager.addWorkerMapping(aDynamicMap, 'aDynamicMap');
+  IsolateManager.addWorkerMapping(a2DTo1DList, 'a2DTo1DList');
+  IsolateManager.addWorkerMapping(fibonacci, 'fibonacci');
+  IsolateManager.addWorkerMapping(fibonacciRecursive, 'fibonacciRecursive');
+  IsolateManager.addWorkerMapping(
+      isolateCallbackSimpleFunctionWithSpecifiedType,
+      'isolateCallbackSimpleFunctionWithSpecifiedType');
+  IsolateManager.addWorkerMapping(aStringList, 'aStringList');
+  IsolateManager.addWorkerMapping(a1DTo2DList, 'a1DTo2DList');
+  IsolateManager.addWorkerMapping(
+      isolateCallbackSimpleFunction, 'isolateCallbackSimpleFunction');
+  IsolateManager.addWorkerMapping(
+      isolateCallbackFunction, 'isolateCallbackFunction');
 }


### PR DESCRIPTION
For #18 

This does not use the `macros` but the current generator to generate the `workerMappings` by adding the `--worker-mappings-experiment=lib/main.dart` flag.

If you want to generate it for testing, you can change the `lib/main.dart` to the `path/to/test.dart`. The generator will inject the needed code into the `main` method.