### PR TITLE
Process the subsequent tasks after receiving an exception

### DIFF
--- a/lib/src/base/contactor/isolate_contactor/web_platform/isolate_contactor_web.dart
+++ b/lib/src/base/contactor/isolate_contactor/web_platform/isolate_contactor_web.dart
@@ -11,7 +11,7 @@ class IsolateContactorInternalFuture<R, P>
       StreamController.broadcast();
 
   /// Listener for result
-  final IsolateContactorController<R, P>? _isolateContactorController;
+  IsolateContactorController<R, P>? _isolateContactorController;
 
   /// Control the function of isolate
   final void Function(dynamic) _isolateFunction;
@@ -80,7 +80,7 @@ class IsolateContactorInternalFuture<R, P>
 
     _isolateFunction([_isolateParam, _isolateContactorController]);
 
-    await _isolateContactorController.ensureInitialized.future;
+    await _isolateContactorController!.ensureInitialized.future;
 
     printDebug(() => 'Initialized');
   }
@@ -96,6 +96,8 @@ class IsolateContactorInternalFuture<R, P>
 
     await _isolateContactorController?.close();
     await _mainStreamController.close();
+
+    _isolateContactorController = null;
 
     printDebug(() => 'Disposed');
   }
@@ -115,7 +117,7 @@ class IsolateContactorInternalFuture<R, P>
 
     final Completer<R> completer = Completer();
     late final StreamSubscription<R> sub;
-    sub = _isolateContactorController.onMessage.listen((result) async {
+    sub = _isolateContactorController!.onMessage.listen((result) async {
       if (!completer.isCompleted) {
         completer.complete(result);
         await sub.cancel();
@@ -128,7 +130,7 @@ class IsolateContactorInternalFuture<R, P>
 
     printDebug(() => 'Message send to isolate: $message');
 
-    _isolateContactorController.sendIsolate(message);
+    _isolateContactorController!.sendIsolate(message);
 
     return completer.future;
   }

--- a/lib/src/base/contactor/isolate_contactor_controller/web_platform/isolate_contactor_controller_web.dart
+++ b/lib/src/base/contactor/isolate_contactor_controller/web_platform/isolate_contactor_controller_web.dart
@@ -55,7 +55,9 @@ class IsolateContactorControllerImplFuture<R, P>
               if (onDispose != null) onDispose!();
               close();
             } else {
-              _isolateStreamController.add(value);
+              if (!_isolateStreamController.isClosed) {
+                _isolateStreamController.add(value);
+              }
             }
             break;
         }
@@ -78,26 +80,37 @@ class IsolateContactorControllerImplFuture<R, P>
   Stream<P> get onIsolateMessage => _isolateStreamController.stream;
 
   @override
-  void initialized() =>
-      _delegate.sink.add({IsolatePort.main: IsolateState.initialized});
+  void initialized() {
+    if (_delegate.isClosed) return;
+
+    _delegate.sink.add({IsolatePort.main: IsolateState.initialized});
+  }
 
   @override
   void sendIsolate(P message) {
+    if (_delegate.isClosed) return;
+
     _delegate.sink.add({IsolatePort.isolate: message});
   }
 
   @override
   void sendIsolateState(IsolateState state) {
+    if (_delegate.isClosed) return;
+
     _delegate.sink.add({IsolatePort.isolate: state});
   }
 
   @override
   void sendResult(R message) {
+    if (_delegate.isClosed) return;
+
     _delegate.sink.add({IsolatePort.main: message});
   }
 
   @override
   void sendResultError(IsolateException exception) {
+    if (_delegate.isClosed) return;
+
     _delegate.sink.add({IsolatePort.main: exception});
   }
 

--- a/lib/src/isolate_manager.dart
+++ b/lib/src/isolate_manager.dart
@@ -242,11 +242,10 @@ class IsolateManager<R, P> {
       ]);
     }
 
-    _streamSubscription = _streamController.stream.listen((result) {
-      _excuteQueue();
-    })
-      // Needs to put onError here to make the try-catch work properly.
-      ..onError((error, stack) {});
+    _streamSubscription = _streamController.stream.listen(
+      (_) => _excuteQueue(),
+      onError: (_, __) => _excuteQueue(),
+    );
 
     _excuteQueue();
 

--- a/test/isolate_manager_test.dart
+++ b/test/isolate_manager_test.dart
@@ -257,6 +257,48 @@ void main() {
     await isolateManager.stop();
   });
 
+  test('Test with all Exception functions with eagerError is true', () async {
+    final isolateManager = IsolateManager<int, List<int>>.create(
+      errorFunction,
+      concurrent: 2,
+    );
+    await isolateManager.start();
+    final futures = <Future<dynamic>>[];
+
+    for (var i = 0; i < 100; i++) {
+      futures.add(isolateManager.compute(<int>[50, 20]));
+    }
+
+    await expectLater(
+      () async => Future.wait(futures, eagerError: true),
+      throwsStateError,
+    );
+    await isolateManager.stop();
+  });
+
+  test(
+      'Test with all Exception functions with eagerError is true with available callback',
+      () async {
+    final isolateManager = IsolateManager<int, List<int>>.create(
+      errorFunction,
+      concurrent: 2,
+    );
+    await isolateManager.start();
+    final futures = <Future<dynamic>>[];
+
+    for (var i = 0; i < 100; i++) {
+      futures.add(
+        isolateManager.compute(<int>[50, 20], callback: (int value) => true),
+      );
+    }
+
+    await expectLater(
+      () async => Future.wait(futures, eagerError: true),
+      throwsStateError,
+    );
+    await isolateManager.stop();
+  });
+
   test('Test with Exception function with eagerError is false', () async {
     final isolateManager = IsolateManager.create(
       errorFunction,
@@ -292,6 +334,48 @@ void main() {
 
     await expectLater(
       () async => await Future.wait(futures, eagerError: false),
+      throwsStateError,
+    );
+    await isolateManager.stop();
+  });
+
+  test('Test with all Exception functions with eagerError is false', () async {
+    final isolateManager = IsolateManager<int, List<int>>.create(
+      errorFunction,
+      concurrent: 2,
+    );
+    await isolateManager.start();
+    final futures = <Future<dynamic>>[];
+
+    for (var i = 0; i < 100; i++) {
+      futures.add(isolateManager.compute(<int>[50, 20]));
+    }
+
+    await expectLater(
+      () async => Future.wait(futures),
+      throwsStateError,
+    );
+    await isolateManager.stop();
+  });
+
+  test(
+      'Test with all Exception functions with eagerError is false with available callback',
+      () async {
+    final isolateManager = IsolateManager<int, List<int>>.create(
+      errorFunction,
+      concurrent: 2,
+    );
+    await isolateManager.start();
+    final futures = <Future<dynamic>>[];
+
+    for (var i = 0; i < 100; i++) {
+      futures.add(
+        isolateManager.compute(<int>[50, 20], callback: (int value) => true),
+      );
+    }
+
+    await expectLater(
+      () async => Future.wait(futures),
       throwsStateError,
     );
     await isolateManager.stop();


### PR DESCRIPTION
Fixes #41 

There is a missing call to execute the next queued computation when receiving an exception, so the isolate will be halted if all isolates receive the exceptions at the same time.

It will work properly if there is at least one isolate that return a normal value.